### PR TITLE
Condition exercism

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,26 +3,34 @@ dotenv_if_exists
 use flake
 
 #auto-setup project
-#elixir
-LOCAL_PATH=$(cd $(dirname ${BASH_SOURCE[0]}); pwd -P)/
-export NIX_SHELL_DIR=$LOCAL_PATH/elixir/.nix-shell
+LOCAL_PATH=$(pwd)
+export NIX_SHELL_DIR="$LOCAL_PATH/.nix-shell"
+export EXERCISM_CONFIG_HOME="$NIX_SHELL_DIR/exercism"
+
 test -d $NIX_SHELL_DIR && mkdir -p $NIX_SHELL_DIR
-export MIX_HOME="$NIX_SHELL_DIR/.mix"
-export MIX_ARCHIVES="$MIX_HOME/archives"
-export HEX_HOME="$NIX_SHELL_DIR/.hex"
+
 export LANG="en_US.UTF-8"
 
+# elixir
+export MIX_HOME="$NIX_SHELL_DIR/elixir/.mix"
+export MIX_ARCHIVES="$MIX_HOME/archives"
+export HEX_HOME="$NIX_SHELL_DIR/elixir/.hex"
+
 if ! test -d $MIX_HOME; then
-  yes | mix local.hex
-  yes | mix local.rebar
+  mix local.hex --force
+  mix local.rebar --force
 fi
 
-#python
-export PYTHONPATH=$LOCAL_PATH/python
+# python
+export PYTHONPATH="$NIX_SHELL_DIR/python"
 
-#exercism
-if [[ -v EXERCISM_TOKEN ]]; then
-  exercism configure --token=$EXERCISM_TOKEN -w=$LOCAL_PATH
-else
-  echo "Please provide an EXERCISM_TOKEN in your environment" 
+# exercism
+if [[ ! -f $EXERCISM_CONFIG_HOME/user.json ]]; then
+    if [[ -v EXERCISM_TOKEN ]]; then
+        if [[ -x "$(command -v exercism)" ]]; then
+            exercism configure --token=$EXERCISM_TOKEN -w $LOCAL_PATH
+        fi
+    else
+        echo "No exercism token found. Please set the EXERCISM_TOKEN environment variable."
+    fi
 fi

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ let
 
   exercismPython = python3.withPackages (p: with p; [pytest pytest-cache pytest-subtests pytest-pylint]);
 
-  fSharp = [exercism dotnet-sdk_7 dotnet-runtime_7];
+  fSharp = [ dotnet-sdk_7 dotnet-runtime_7];
 in
 
 mkShell {


### PR DESCRIPTION
# Description

The path home for exercism config was on xdg.configFile."exercism", turning the flake impure. I changed to local path on `.nix-shell`. I added new conditions to check if the package exercism exists then generate or not a new config user.json

# Motivation

- I changed the base struct to support more programming languages in the future.